### PR TITLE
fix(lock): lock file wasn't compute for skills

### DIFF
--- a/cmd/cops/main.go
+++ b/cmd/cops/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"cops/internal/cli"
+	"github.com/cbout22/copilot-sync/internal/cli"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module cops
+module github.com/cbout22/copilot-sync
 
 go 1.25.6
 

--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"cops/internal/config"
-	"cops/internal/manifest"
+	"github.com/cbout22/copilot-sync/internal/config"
+	"github.com/cbout22/copilot-sync/internal/manifest"
 )
 
 // newCheckCmd creates the `check` command.

--- a/internal/cli/sync.go
+++ b/internal/cli/sync.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"cops/internal/auth"
-	"cops/internal/config"
-	"cops/internal/injector"
-	"cops/internal/manifest"
-	"cops/internal/resolver"
+	"github.com/cbout22/copilot-sync/internal/auth"
+	"github.com/cbout22/copilot-sync/internal/config"
+	"github.com/cbout22/copilot-sync/internal/injector"
+	"github.com/cbout22/copilot-sync/internal/manifest"
+	"github.com/cbout22/copilot-sync/internal/resolver"
 )
 
 // newSyncCmd creates the `sync` command.

--- a/internal/cli/unuse.go
+++ b/internal/cli/unuse.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"cops/internal/config"
-	"cops/internal/manifest"
+	"github.com/cbout22/copilot-sync/internal/config"
+	"github.com/cbout22/copilot-sync/internal/manifest"
 )
 
 // newUnuseCmd creates the `unuse` subcommand for a given asset type.

--- a/internal/cli/use.go
+++ b/internal/cli/use.go
@@ -5,11 +5,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"cops/internal/auth"
-	"cops/internal/config"
-	"cops/internal/injector"
-	"cops/internal/manifest"
-	"cops/internal/resolver"
+	"github.com/cbout22/copilot-sync/internal/auth"
+	"github.com/cbout22/copilot-sync/internal/config"
+	"github.com/cbout22/copilot-sync/internal/injector"
+	"github.com/cbout22/copilot-sync/internal/manifest"
+	"github.com/cbout22/copilot-sync/internal/resolver"
 )
 
 // newUseCmd creates the `use` subcommand for a given asset type.

--- a/internal/injector/injector.go
+++ b/internal/injector/injector.go
@@ -6,9 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 
-	"cops/internal/config"
-	"cops/internal/manifest"
-	"cops/internal/resolver"
+	"github.com/cbout22/copilot-sync/internal/config"
+	"github.com/cbout22/copilot-sync/internal/manifest"
+	"github.com/cbout22/copilot-sync/internal/resolver"
 )
 
 // Injector downloads assets from GitHub and writes them to the correct

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"strings"
 
-	"cops/internal/config"
+	"github.com/cbout22/copilot-sync/internal/config"
 )
 
 const githubAPIBase = "https://api.github.com"


### PR DESCRIPTION
This pull request updates the project module path and refactors all internal import statements to use the new module path. Additionally, it introduces a new utility function for computing directory checksums and improves the asset injection process by tracking file contents and updating lock files with combined checksums.

Module path and import refactoring:

* Changed the module path in `go.mod` from `module cops` to `module github.com/cbout22/copilot-sync`, and updated all internal import statements throughout the codebase to reference `github.com/cbout22/copilot-sync/...` instead of `cops/...`. [[1]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L1-R1) [[2]](diffhunk://#diff-dbd1d83afbbad7949c93d32bbc7b0e41d0a9c7786bda3d02698bdb3c1f7cb151L4-R4) [[3]](diffhunk://#diff-3fd5747ac1ce697a2360abaec39ba81c6c390a122f7dc826984b080da4bc4f7cL9-R10) [[4]](diffhunk://#diff-27ce57d2792cee1ce08224dd1d55fbecec97e0e6085cd5b4a2dd073284b7abf9L8-R12) [[5]](diffhunk://#diff-8c68596c79597f9974fc102849a0dd0c53295019f6de3f15f4712316206e3eb1L9-R10) [[6]](diffhunk://#diff-0dc64f56cda7f9c63a1d1151ed7b29e484c4422e19672df828b8341f03f08be7L8-R12) [[7]](diffhunk://#diff-192007c8d41c31230797983a67b7515201f75f47b98aa2a5d778a0390b3c060dL9-R11) [[8]](diffhunk://#diff-ff3593e6a6cb00f927118c829760e054ccca7686eae492f9f4f18b9b851a9a20L10-R10)

Asset injection enhancements:

* Added `computeDirectoryChecksum` function to create a combined checksum for all files in a directory, improving integrity verification for skills and assets.
* Updated the `injectDirectory` method in `internal/injector/injector.go` to track downloaded file contents, resolve commit SHA, and update the lock file with a combined checksum for the directory. [[1]](diffhunk://#diff-192007c8d41c31230797983a67b7515201f75f47b98aa2a5d778a0390b3c060dR125-R127) [[2]](diffhunk://#diff-192007c8d41c31230797983a67b7515201f75f47b98aa2a5d778a0390b3c060dR159-R174)