### PR TITLE
chore(cd): release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,33 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          SCOOP_BUCKET_TOKEN: ${{ secrets.SCOOP_BUCKET_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@ go.work.sum
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# GoReleaser output
+dist/
+
+# Built binary
+cops

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,88 @@
+version: 2
+
+project_name: cops
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: cops
+    main: ./cmd/cops/
+    binary: cops
+    env:
+      - CGO_ENABLED=0
+    ldflags:
+      - -s -w
+      - -X github.com/cbout22/copilot-sync/internal/cli.version={{.Version}}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+
+archives:
+  - id: default
+    formats: tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats: zip
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+
+# ── Homebrew ──────────────────────────────────────────────
+homebrew_casks:
+  - repository:
+      owner: cbout22
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    homepage: "https://github.com/cbout22/copilot-sync"
+    description: "The deterministic package manager for your GitHub Copilot agent files"
+    license: "MIT"
+    binaries:
+      - cops
+
+# ── APT / Debian + RPM ───────────────────────────────────
+nfpms:
+  - id: deb
+    package_name: cops
+    vendor: cbout22
+    homepage: "https://github.com/cbout22/copilot-sync"
+    maintainer: "cbout22 <cbout22@users.noreply.github.com>"
+    description: "The deterministic package manager for your GitHub Copilot agent files"
+    license: MIT
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+
+# ── Windows (Scoop) ──────────────────────────────────────
+scoops:
+  - repository:
+      owner: cbout22
+      name: scoop-bucket
+      token: "{{ .Env.SCOOP_BUCKET_TOKEN }}"
+    homepage: "https://github.com/cbout22/copilot-sync"
+    description: "The deterministic package manager for your GitHub Copilot agent files"
+    license: MIT
+
+release:
+  github:
+    owner: cbout22
+    name: copilot-sync
+  draft: false
+  prerelease: auto
+  name_template: "v{{.Version}}"


### PR DESCRIPTION
This pull request introduces a full release automation setup for the project, enabling streamlined cross-platform builds and automated publishing to popular package managers. The changes add a GitHub Actions workflow for releases and a comprehensive GoReleaser configuration.

Release automation and packaging:

* Added a `.github/workflows/release.yml` GitHub Actions workflow to automate releases on tag pushes, including building and publishing artifacts using GoReleaser, with support for Homebrew and Scoop tokens.
* Introduced a `.goreleaser.yaml` configuration to build the `cops` binary for Linux, macOS, and Windows (amd64 and arm64), package releases as tar.gz (and zip for Windows), and publish to Homebrew, APT/RPM, and Scoop repositories, with changelog and checksum generation.