### PR TITLE
feat(cli): adding a basic lazy loaded completion for adding and removing agent

### DIFF
--- a/internal/cli/completion_unuse.go
+++ b/internal/cli/completion_unuse.go
@@ -1,0 +1,32 @@
+package cli
+
+import (
+	"strings"
+
+	"github.com/cbout22/copilot-sync/internal/manifest"
+	"github.com/spf13/cobra"
+)
+
+func resolveManifestName(assetType string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// Load the manifest
+	m, err := manifest.Load(manifest.DefaultManifestFile)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// Get all asset names for the given type
+	names, err := m.Section(assetType)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// Filter based on toComplete prefix
+	var completions []string
+	for name, ref := range names {
+		if strings.HasPrefix(name, toComplete) {
+			completions = append(completions, formatCompletionLine(name, ref))
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/internal/cli/completion_use.go
+++ b/internal/cli/completion_use.go
@@ -1,0 +1,220 @@
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/cbout22/copilot-sync/internal/auth"
+)
+
+const githubAPIBase = "https://api.github.com"
+
+// resolveGitHubCompletions provides dynamic shell completion for GitHub assets.
+func resolveGitHubCompletions(toComplete string) ([]string, cobra.ShellCompDirective) {
+	// Use a short timeout to prevent blocking the shell
+	client, err := auth.NewHTTPClientWithTimeout(time.Second)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// 1. Version state: Typing `@`
+	if idx := strings.Index(toComplete, "@"); idx != -1 {
+		repoPart := toComplete[:idx]
+		refPart := toComplete[idx+1:]
+		return completeRefs(client, repoPart, refPart)
+	}
+
+	// 2. Path state: Typing `repo/` (after `org/repo/`)
+	parts := strings.Split(toComplete, "/")
+	if len(parts) >= 3 {
+		org := parts[0]
+		repo := parts[1]
+		pathPrefix := strings.Join(parts[2:], "/")
+		return completePaths(client, org, repo, pathPrefix, toComplete)
+	}
+
+	// 3. Org/Repo state: Typing `org/` or just `org`
+	return completeRepos(client, toComplete)
+}
+
+func completeRepos(client *http.Client, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// If it's empty, we can't really search effectively without a query
+	if toComplete == "" {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	// Search repositories
+	// If user typed "org/", search for "user:org" or "org:org"
+	// If user typed "org/re", search for "repo:org/re" or "org/re in:name"
+	query := toComplete
+	if strings.Contains(toComplete, "/") {
+		parts := strings.SplitN(toComplete, "/", 2)
+		org := parts[0]
+		repoPrefix := parts[1]
+		query = fmt.Sprintf("user:%s %s in:name", org, repoPrefix)
+	}
+
+	searchURL := fmt.Sprintf("%s/search/repositories?q=%s&per_page=10", githubAPIBase, url.QueryEscape(query))
+	resp, err := client.Get(searchURL)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Items []struct {
+			FullName    string `json:"full_name"`
+			Description string `json:"description"`
+		} `json:"items"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var completions []string
+	for _, item := range result.Items {
+		if strings.HasPrefix(item.FullName, toComplete) {
+			desc := item.Description
+			if desc == "" {
+				desc = "Repository"
+			}
+			// Truncate description if too long
+			if len(desc) > 60 {
+				desc = desc[:57] + "..."
+			}
+			// Add trailing slash to encourage path completion
+			completions = append(completions, formatCompletionLine(item.FullName, desc))
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
+}
+
+func completePaths(client *http.Client, org, repo, pathPrefix, fullToComplete string) ([]string, cobra.ShellCompDirective) {
+	// We need to get the default branch first to get the tree, or just use HEAD
+	// Actually, we can use HEAD for the tree
+	treeURL := fmt.Sprintf("%s/repos/%s/%s/git/trees/HEAD?recursive=1", githubAPIBase, org, repo)
+	resp, err := client.Get(treeURL)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		Tree []struct {
+			Path string `json:"path"`
+			Type string `json:"type"`
+		} `json:"tree"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var completions []string
+	basePrefix := fmt.Sprintf("%s/%s/", org, repo)
+
+	// We only want to suggest the next level of directories or matching files
+	// Since we have recursive=1, we get all paths.
+	// We should filter paths that start with pathPrefix
+
+	seenDirs := make(map[string]bool)
+
+	for _, item := range result.Tree {
+		if !strings.HasPrefix(item.Path, pathPrefix) {
+			continue
+		}
+
+		// If it's a file, only suggest .md files
+		if item.Type == "blob" && !strings.HasSuffix(item.Path, ".md") {
+			continue
+		}
+
+		// We want to suggest the immediate next segment
+		remainingPath := strings.TrimPrefix(item.Path, pathPrefix)
+		segments := strings.Split(remainingPath, "/")
+
+		if len(segments) > 1 {
+			// It's a directory further down
+			nextDir := pathPrefix + segments[0] + "/"
+			if !seenDirs[nextDir] {
+				seenDirs[nextDir] = true
+				completions = append(completions, formatCompletionLine(basePrefix+nextDir, "Directory"))
+			}
+		} else {
+			// It's an immediate file or directory
+			if item.Type == "tree" {
+				dirPath := item.Path + "/"
+				if !seenDirs[dirPath] {
+					seenDirs[dirPath] = true
+					completions = append(completions, formatCompletionLine(basePrefix+dirPath, "Directory"))
+				}
+			} else {
+				completions = append(completions, formatCompletionLine(basePrefix+item.Path, "Markdown File"))
+			}
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoSpace | cobra.ShellCompDirectiveNoFileComp
+}
+
+func completeRefs(client *http.Client, repoPart, refPart string) ([]string, cobra.ShellCompDirective) {
+	parts := strings.Split(repoPart, "/")
+	if len(parts) < 3 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	org := parts[0]
+	repo := parts[1]
+
+	var completions []string
+
+	// Always suggest latest if it matches
+	if strings.HasPrefix("latest", refPart) {
+		completions = append(completions, formatCompletionLine(fmt.Sprintf("%s@latest", repoPart), "Default branch"))
+	}
+
+	// Fetch refs
+	refsURL := fmt.Sprintf("%s/repos/%s/%s/git/refs", githubAPIBase, org, repo)
+	resp, err := client.Get(refsURL)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+	defer resp.Body.Close()
+
+	var result []struct {
+		Ref string `json:"ref"`
+	}
+
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return completions, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	for _, item := range result {
+		// Only suggest branches and tags
+		if !strings.HasPrefix(item.Ref, "refs/heads/") && !strings.HasPrefix(item.Ref, "refs/tags/") {
+			continue
+		}
+
+		// refs/heads/main -> main
+		// refs/tags/v1.0 -> v1.0
+		shortRef := strings.TrimPrefix(item.Ref, "refs/heads/")
+		shortRef = strings.TrimPrefix(shortRef, "refs/tags/")
+
+		if strings.HasPrefix(shortRef, refPart) {
+			desc := "Branch"
+			if strings.HasPrefix(item.Ref, "refs/tags/") {
+				desc = "Tag"
+			}
+			completions = append(completions, formatCompletionLine(fmt.Sprintf("%s@%s", repoPart, shortRef), desc))
+		}
+	}
+
+	return completions, cobra.ShellCompDirectiveNoFileComp
+}

--- a/internal/cli/formater.go
+++ b/internal/cli/formater.go
@@ -1,0 +1,5 @@
+package cli
+
+func formatCompletionLine(content string, helper string) string {
+	return content + "\t" + helper
+}

--- a/internal/cli/unuse.go
+++ b/internal/cli/unuse.go
@@ -22,6 +22,9 @@ corresponding local file or directory from disk.
 Example:
   cops %s unuse my-asset`, typeName, typeName),
 		Args: cobra.ExactArgs(1),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			return resolveManifestName(typeName, toComplete)
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 			return runUnuse(typeName, name)

--- a/internal/cli/use.go
+++ b/internal/cli/use.go
@@ -23,6 +23,12 @@ func newUseCmd(typeName string) *cobra.Command {
 Example:
   cops %s use my-asset my-org/repo/path/to/file@v1.0`, typeName, typeName),
 		Args: cobra.ExactArgs(2),
+		ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+			if len(args) == 1 {
+				return resolveGitHubCompletions(toComplete)
+			}
+			return nil, cobra.ShellCompDirectiveDefault
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			name := args[0]
 			rawRef := args[1]


### PR DESCRIPTION
This pull request introduces dynamic shell completion for asset names and GitHub references in the CLI, and improves file injection reliability. The main changes add context-aware completion for both `use` and `unuse` commands, implement helper functions for formatting completion results, and ensure injected files are safely updated.

**Shell completion improvements:**

* Added dynamic shell completion for asset names in the `unuse` command using the manifest, improving usability when removing assets. [[1]](diffhunk://#diff-8c68596c79597f9974fc102849a0dd0c53295019f6de3f15f4712316206e3eb1R25-R27) [[2]](diffhunk://#diff-7500e71c13af304409b6b6797bc6e1459c13ade25990a8a69860907aeb2a121cR1-R32)
* Implemented advanced shell completion for the `use` command, supporting GitHub repository, path, and ref suggestions by querying the GitHub API with a short timeout. [[1]](diffhunk://#diff-0dc64f56cda7f9c63a1d1151ed7b29e484c4422e19672df828b8341f03f08be7R26-R31) [[2]](diffhunk://#diff-5b4564403430cd70af1114f3786391607a116f387ba7ba5bb87708f0e2a0100bR1-R220)
* Introduced a helper function `formatCompletionLine` to format completion results with descriptions for a better shell experience.

**HTTP client enhancements:**

* Refactored the HTTP client creation in `internal/auth/auth.go` to allow specifying a timeout, enabling responsive completions and safer API calls. [[1]](diffhunk://#diff-69673fb1085db41e623b0fb8adc07c7396117ca9c37992e72dd1d7b8f2665f7fR7) [[2]](diffhunk://#diff-69673fb1085db41e623b0fb8adc07c7396117ca9c37992e72dd1d7b8f2665f7fR36-R51)

**File injection robustness:**

* Improved the file injection process to always remove any existing target file before writing a new one, preventing stale content issues and ensuring the lock file is updated with the correct commit SHA.