### PR TITLE
fix(lock): locking retrieves sha correctly

### DIFF
--- a/internal/injector/injector.go
+++ b/internal/injector/injector.go
@@ -75,7 +75,7 @@ func (inj *Injector) injectFile(ref config.AssetRef, absTarget string, assetType
 	}
 
 	// Resolve commit SHA for the lock file
-	sha, err := inj.resolver.ResolveCommitSHA(ref)
+	sha, err := inj.resolver.ResolveSHA(ref)
 	if err != nil {
 		return fmt.Errorf("resolving commit SHA: %w", err)
 	}
@@ -167,7 +167,7 @@ func (inj *Injector) injectDirectory(ref config.AssetRef, absTargetDir string) e
 	}
 
 	// Resolve commit SHA for the lock file
-	sha, err := inj.resolver.ResolveCommitSHA(ref)
+	sha, err := inj.resolver.ResolveSHA(ref)
 	if err != nil {
 		// Non-fatal: we still wrote the files, just can't lock the SHA
 		sha = "unknown"


### PR DESCRIPTION
This pull request refactors how commit SHAs are resolved for GitHub repositories, improving clarity and reliability in the resolver logic. The most significant changes are the renaming and enhancement of the commit SHA resolution method, improved handling of the "latest" branch alias, and updates to related code to use the new method.

### Resolver logic improvements

* Renamed `ResolveCommitSHA` to `ResolveSHA` in `internal/resolver/resolver.go`, and updated its implementation to parse the commit SHA from the JSON response instead of reading the raw body as a string. This makes the method more robust and consistent with GitHub's API responses. [[1]](diffhunk://#diff-ff3593e6a6cb00f927118c829760e054ccca7686eae492f9f4f18b9b851a9a20L175-L191) [[2]](diffhunk://#diff-ff3593e6a6cb00f927118c829760e054ccca7686eae492f9f4f18b9b851a9a20L204-R215)
* Added a new helper method `ResolveDefaultBranchName` to fetch the default branch name for a repository, and refactored `ResolveRef` to use this helper for resolving the "latest" alias.

### Injector updates

* Updated calls in `internal/injector/injector.go` to use the new `ResolveSHA` method instead of the old `ResolveCommitSHA` for both file and directory injection operations. [[1]](diffhunk://#diff-192007c8d41c31230797983a67b7515201f75f47b98aa2a5d778a0390b3c060dL78-R78) [[2]](diffhunk://#diff-192007c8d41c31230797983a67b7515201f75f47b98aa2a5d778a0390b3c060dL170-R170)