### PR TITLE
chore(ci): adding UT

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    if: github.repository == 'cbout22/copilot-sync'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests with coverage
+        run: go test -race -coverprofile=coverage.out -covermode=atomic ./...
+
+      - name: Coverage summary
+        run: go tool cover -func=coverage.out
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: coverage.out


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for continuous integration (CI). The workflow is designed to automatically run tests and generate coverage reports for the repository on pushes and pull requests to the `main` branch.

Continuous integration workflow setup:

* Added `.github/workflows/ci.yml` to define a CI pipeline that runs on pushes and pull requests to the `main` branch.
* Configured the workflow to check out the repository, set up Go using the version specified in `go.mod`, run tests with race detection and coverage, summarize coverage, and upload the coverage report as an artifact.