### PR TITLE
feat: verify local file checksums in check command

### DIFF
--- a/internal/cli/check.go
+++ b/internal/cli/check.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"github.com/spf13/cobra"
 
@@ -84,7 +85,17 @@ func runCheckWith(strict bool, manifestPath, lockPath, rootDir string) error {
 			fmt.Printf("  ⚠️  %s/%s — ref changed: lock=%s manifest=%s\n", entry.Type, entry.Name, lockEntry.Ref, entry.Ref)
 			issues++
 		default:
-			fmt.Printf("  ✅ %s/%s — ok\n", entry.Type, entry.Name)
+			// fileExists && locked && refs match — verify content integrity
+			cs, err := localChecksum(targetPath, assetType.IsDirectory())
+			if err != nil {
+				fmt.Printf("  ❌ %s/%s — error reading local file: %v\n", entry.Type, entry.Name, err)
+				issues++
+			} else if cs != lockEntry.Checksum {
+				fmt.Printf("  ❌ %s/%s — content modified (checksum mismatch)\n", entry.Type, entry.Name)
+				issues++
+			} else {
+				fmt.Printf("  ✅ %s/%s — ok\n", entry.Type, entry.Name)
+			}
 		}
 	}
 
@@ -101,4 +112,49 @@ func runCheckWith(strict bool, manifestPath, lockPath, rootDir string) error {
 	}
 
 	return nil
+}
+
+// localChecksum computes the SHA-256 checksum of a local file or directory,
+// using the same algorithm as the injector for comparison against lock file entries.
+func localChecksum(path string, isDir bool) (string, error) {
+	if !isDir {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return "", err
+		}
+		return manifest.Checksum(data), nil
+	}
+
+	// For directories: collect files in sorted order and concatenate content,
+	// matching the deterministic algorithm used by the injector.
+	type filePair struct {
+		rel  string
+		data []byte
+	}
+	var pairs []filePair
+	err := filepath.Walk(path, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(path, p)
+		data, err := os.ReadFile(p)
+		if err != nil {
+			return err
+		}
+		pairs = append(pairs, filePair{rel, data})
+		return nil
+	})
+	if err != nil {
+		return "", err
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].rel < pairs[j].rel })
+
+	var combined []byte
+	for _, p := range pairs {
+		combined = append(combined, p.data...)
+	}
+	return manifest.Checksum(combined), nil
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/cbout22/copilot-sync/internal/config"
+	"github.com/cbout22/copilot-sync/internal/manifest"
 	"github.com/cbout22/copilot-sync/internal/resolver"
 )
 
@@ -225,10 +226,10 @@ func TestUnuseCmd_NotFound(t *testing.T) {
 func TestCheckCmd_AllInSync(t *testing.T) {
 	t.Parallel()
 
-	manifest := `[instructions]
+	toml := `[instructions]
 setup = "myorg/myrepo/instructions/setup@v1.0"
 `
-	dir, manifestPath, lockPath := setupTestDir(t, manifest)
+	dir, manifestPath, lockPath := setupTestDir(t, toml)
 
 	// Create the file on disk
 	targetDir := filepath.Join(dir, ".github", "instructions")
@@ -240,22 +241,11 @@ setup = "myorg/myrepo/instructions/setup@v1.0"
 		t.Fatal(err)
 	}
 
-	// Create a matching lock file
-	lockContent := `{
-  "version": 1,
-  "entries": {
-    "instructions/setup": {
-      "type": "instructions",
-      "name": "setup",
-      "ref": "myorg/myrepo/instructions/setup@v1.0",
-      "resolved_sha": "abc123",
-      "target_path": ".github/instructions/setup.instructions.md",
-      "checksum": "abc",
-      "synced_at": "2025-01-01T00:00:00Z"
-    }
-  }
-}`
-	if err := os.WriteFile(lockPath, []byte(lockContent), 0644); err != nil {
+	// Create a matching lock file with the correct checksum for "content"
+	lf := manifest.NewLockFile()
+	lf.Set("instructions", "setup", "myorg/myrepo/instructions/setup@v1.0", "abc123",
+		".github/instructions/setup.instructions.md", []byte("content"))
+	if err := lf.Save(lockPath); err != nil {
 		t.Fatal(err)
 	}
 
@@ -353,6 +343,49 @@ setup = "myorg/myrepo/instructions/setup@v2.0"
 	err = runCheckWith(true, manifestPath, lockPath, dir)
 	if err == nil {
 		t.Fatal("runCheckWith(ref changed, strict): expected error, got nil")
+	}
+}
+
+func TestCheckCmd_ChecksumMismatch(t *testing.T) {
+	t.Parallel()
+
+	manifestContent := `[instructions]
+setup = "myorg/myrepo/instructions/setup@v1.0"
+`
+	dir, manifestPath, lockPath := setupTestDir(t, manifestContent)
+
+	// Write a file with different content than what the lock records
+	targetDir := filepath.Join(dir, ".github", "instructions")
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(targetDir, "setup.instructions.md"), []byte("original"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Lock was synced with "original", but now file contains "tampered"
+	lf := manifest.NewLockFile()
+	lf.Set("instructions", "setup", "myorg/myrepo/instructions/setup@v1.0", "abc123",
+		".github/instructions/setup.instructions.md", []byte("original"))
+	if err := lf.Save(lockPath); err != nil {
+		t.Fatal(err)
+	}
+
+	// Tamper with the file after locking
+	if err := os.WriteFile(filepath.Join(targetDir, "setup.instructions.md"), []byte("tampered"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Non-strict: should succeed but report the mismatch
+	err := runCheckWith(false, manifestPath, lockPath, dir)
+	if err != nil {
+		t.Fatalf("runCheckWith(mismatch, non-strict): unexpected error: %v", err)
+	}
+
+	// Strict: should fail
+	err = runCheckWith(true, manifestPath, lockPath, dir)
+	if err == nil {
+		t.Fatal("runCheckWith(mismatch, strict): expected error, got nil")
 	}
 }
 

--- a/internal/manifest/lock.go
+++ b/internal/manifest/lock.go
@@ -91,7 +91,7 @@ func (lf *LockFile) Set(assetType, name, ref, resolvedSHA, targetPath string, co
 		Ref:         ref,
 		ResolvedSHA: resolvedSHA,
 		TargetPath:  targetPath,
-		Checksum:    checksum(content),
+		Checksum:    Checksum(content),
 		SyncedAt:    time.Now().UTC().Format(time.RFC3339),
 	}
 }
@@ -109,8 +109,8 @@ func (lf *LockFile) Remove(assetType, name string) {
 	delete(lf.Entries, key)
 }
 
-// checksum returns the hex-encoded SHA-256 of the given data.
-func checksum(data []byte) string {
+// Checksum returns the hex-encoded SHA-256 of the given data.
+func Checksum(data []byte) string {
 	h := sha256.Sum256(data)
 	return fmt.Sprintf("%x", h)
 }

--- a/internal/manifest/lock_test.go
+++ b/internal/manifest/lock_test.go
@@ -25,24 +25,24 @@ func TestNewLockFile(t *testing.T) {
 	}
 }
 
-// --- checksum ---
+// --- Checksum ---
 
 func TestChecksum_KnownValue(t *testing.T) {
 	t.Parallel()
 	// echo -n "hello" | sha256sum
-	got := checksum([]byte("hello"))
+	got := Checksum([]byte("hello"))
 	want := "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
 	if got != want {
-		t.Errorf("checksum(\"hello\") = %q, want %q", got, want)
+		t.Errorf("Checksum(\"hello\") = %q, want %q", got, want)
 	}
 }
 
 func TestChecksum_Deterministic(t *testing.T) {
 	t.Parallel()
 	data := []byte("some content here")
-	c1 := checksum(data)
+	c1 := Checksum(data)
 	for i := 0; i < 100; i++ {
-		if got := checksum(data); got != c1 {
+		if got := Checksum(data); got != c1 {
 			t.Fatalf("iteration %d: checksum differs: %q vs %q", i, got, c1)
 		}
 	}
@@ -50,10 +50,10 @@ func TestChecksum_Deterministic(t *testing.T) {
 
 func TestChecksum_EmptyInput(t *testing.T) {
 	t.Parallel()
-	got := checksum([]byte{})
+	got := Checksum([]byte{})
 	want := "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 	if got != want {
-		t.Errorf("checksum(empty) = %q, want %q", got, want)
+		t.Errorf("Checksum(empty) = %q, want %q", got, want)
 	}
 }
 
@@ -102,7 +102,7 @@ func TestLockFile_Set_FieldsPopulated(t *testing.T) {
 		t.Errorf("TargetPath = %q", entry.TargetPath)
 	}
 
-	expectedChecksum := checksum(content)
+	expectedChecksum := Checksum(content)
 	if entry.Checksum != expectedChecksum {
 		t.Errorf("Checksum = %q, want %q", entry.Checksum, expectedChecksum)
 	}


### PR DESCRIPTION
The check command now reads local files and compares their SHA-256 checksum against the value stored in the lock file, detecting content modifications made outside of cops.